### PR TITLE
remove manifest references

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,9 +33,6 @@ archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
-  extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 signs:
@@ -51,9 +48,6 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,6 +1,0 @@
-{
-  "version": 1,
-  "metadata": {
-    "protocol_versions": ["5.0"],
-  },
-}


### PR DESCRIPTION
Had issues with pushing to the public registry. Comparing with other providers there doesn't appear to be manifests used.